### PR TITLE
feat(db): update database schema for multiple authors

### DIFF
--- a/lib/db/database.g.dart
+++ b/lib/db/database.g.dart
@@ -33,10 +33,12 @@ class $PoemsTable extends Poems with TableInfo<$PoemsTable, Poem> {
     type: DriftSqlType.string,
     requiredDuringInsert: true,
   );
-  static const VerificationMeta _authorMeta = const VerificationMeta('author');
+  static const VerificationMeta _authorNamesMeta = const VerificationMeta(
+    'authorNames',
+  );
   @override
-  late final GeneratedColumn<String> author = GeneratedColumn<String>(
-    'author',
+  late final GeneratedColumn<String> authorNames = GeneratedColumn<String>(
+    'author_names',
     aliasedName,
     false,
     type: DriftSqlType.string,
@@ -75,7 +77,7 @@ class $PoemsTable extends Poems with TableInfo<$PoemsTable, Poem> {
   List<GeneratedColumn> get $columns => [
     id,
     title,
-    author,
+    authorNames,
     body,
     year,
     altTitles,
@@ -103,13 +105,16 @@ class $PoemsTable extends Poems with TableInfo<$PoemsTable, Poem> {
     } else if (isInserting) {
       context.missing(_titleMeta);
     }
-    if (data.containsKey('author')) {
+    if (data.containsKey('author_names')) {
       context.handle(
-        _authorMeta,
-        author.isAcceptableOrUnknown(data['author']!, _authorMeta),
+        _authorNamesMeta,
+        authorNames.isAcceptableOrUnknown(
+          data['author_names']!,
+          _authorNamesMeta,
+        ),
       );
     } else if (isInserting) {
-      context.missing(_authorMeta);
+      context.missing(_authorNamesMeta);
     }
     if (data.containsKey('body')) {
       context.handle(
@@ -148,9 +153,9 @@ class $PoemsTable extends Poems with TableInfo<$PoemsTable, Poem> {
         DriftSqlType.string,
         data['${effectivePrefix}title'],
       )!,
-      author: attachedDatabase.typeMapping.read(
+      authorNames: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
-        data['${effectivePrefix}author'],
+        data['${effectivePrefix}author_names'],
       )!,
       body: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
@@ -176,14 +181,14 @@ class $PoemsTable extends Poems with TableInfo<$PoemsTable, Poem> {
 class Poem extends DataClass implements Insertable<Poem> {
   final int id;
   final String title;
-  final String author;
+  final String authorNames;
   final String body;
   final String? year;
   final String? altTitles;
   const Poem({
     required this.id,
     required this.title,
-    required this.author,
+    required this.authorNames,
     required this.body,
     this.year,
     this.altTitles,
@@ -193,7 +198,7 @@ class Poem extends DataClass implements Insertable<Poem> {
     final map = <String, Expression>{};
     map['id'] = Variable<int>(id);
     map['title'] = Variable<String>(title);
-    map['author'] = Variable<String>(author);
+    map['author_names'] = Variable<String>(authorNames);
     map['body'] = Variable<String>(body);
     if (!nullToAbsent || year != null) {
       map['year'] = Variable<String>(year);
@@ -208,7 +213,7 @@ class Poem extends DataClass implements Insertable<Poem> {
     return PoemsCompanion(
       id: Value(id),
       title: Value(title),
-      author: Value(author),
+      authorNames: Value(authorNames),
       body: Value(body),
       year: year == null && nullToAbsent ? const Value.absent() : Value(year),
       altTitles: altTitles == null && nullToAbsent
@@ -225,7 +230,7 @@ class Poem extends DataClass implements Insertable<Poem> {
     return Poem(
       id: serializer.fromJson<int>(json['id']),
       title: serializer.fromJson<String>(json['title']),
-      author: serializer.fromJson<String>(json['author']),
+      authorNames: serializer.fromJson<String>(json['authorNames']),
       body: serializer.fromJson<String>(json['body']),
       year: serializer.fromJson<String?>(json['year']),
       altTitles: serializer.fromJson<String?>(json['altTitles']),
@@ -237,7 +242,7 @@ class Poem extends DataClass implements Insertable<Poem> {
     return <String, dynamic>{
       'id': serializer.toJson<int>(id),
       'title': serializer.toJson<String>(title),
-      'author': serializer.toJson<String>(author),
+      'authorNames': serializer.toJson<String>(authorNames),
       'body': serializer.toJson<String>(body),
       'year': serializer.toJson<String?>(year),
       'altTitles': serializer.toJson<String?>(altTitles),
@@ -247,14 +252,14 @@ class Poem extends DataClass implements Insertable<Poem> {
   Poem copyWith({
     int? id,
     String? title,
-    String? author,
+    String? authorNames,
     String? body,
     Value<String?> year = const Value.absent(),
     Value<String?> altTitles = const Value.absent(),
   }) => Poem(
     id: id ?? this.id,
     title: title ?? this.title,
-    author: author ?? this.author,
+    authorNames: authorNames ?? this.authorNames,
     body: body ?? this.body,
     year: year.present ? year.value : this.year,
     altTitles: altTitles.present ? altTitles.value : this.altTitles,
@@ -263,7 +268,9 @@ class Poem extends DataClass implements Insertable<Poem> {
     return Poem(
       id: data.id.present ? data.id.value : this.id,
       title: data.title.present ? data.title.value : this.title,
-      author: data.author.present ? data.author.value : this.author,
+      authorNames: data.authorNames.present
+          ? data.authorNames.value
+          : this.authorNames,
       body: data.body.present ? data.body.value : this.body,
       year: data.year.present ? data.year.value : this.year,
       altTitles: data.altTitles.present ? data.altTitles.value : this.altTitles,
@@ -275,7 +282,7 @@ class Poem extends DataClass implements Insertable<Poem> {
     return (StringBuffer('Poem(')
           ..write('id: $id, ')
           ..write('title: $title, ')
-          ..write('author: $author, ')
+          ..write('authorNames: $authorNames, ')
           ..write('body: $body, ')
           ..write('year: $year, ')
           ..write('altTitles: $altTitles')
@@ -284,14 +291,15 @@ class Poem extends DataClass implements Insertable<Poem> {
   }
 
   @override
-  int get hashCode => Object.hash(id, title, author, body, year, altTitles);
+  int get hashCode =>
+      Object.hash(id, title, authorNames, body, year, altTitles);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is Poem &&
           other.id == this.id &&
           other.title == this.title &&
-          other.author == this.author &&
+          other.authorNames == this.authorNames &&
           other.body == this.body &&
           other.year == this.year &&
           other.altTitles == this.altTitles);
@@ -300,14 +308,14 @@ class Poem extends DataClass implements Insertable<Poem> {
 class PoemsCompanion extends UpdateCompanion<Poem> {
   final Value<int> id;
   final Value<String> title;
-  final Value<String> author;
+  final Value<String> authorNames;
   final Value<String> body;
   final Value<String?> year;
   final Value<String?> altTitles;
   const PoemsCompanion({
     this.id = const Value.absent(),
     this.title = const Value.absent(),
-    this.author = const Value.absent(),
+    this.authorNames = const Value.absent(),
     this.body = const Value.absent(),
     this.year = const Value.absent(),
     this.altTitles = const Value.absent(),
@@ -315,17 +323,17 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
   PoemsCompanion.insert({
     this.id = const Value.absent(),
     required String title,
-    required String author,
+    required String authorNames,
     required String body,
     this.year = const Value.absent(),
     this.altTitles = const Value.absent(),
   }) : title = Value(title),
-       author = Value(author),
+       authorNames = Value(authorNames),
        body = Value(body);
   static Insertable<Poem> custom({
     Expression<int>? id,
     Expression<String>? title,
-    Expression<String>? author,
+    Expression<String>? authorNames,
     Expression<String>? body,
     Expression<String>? year,
     Expression<String>? altTitles,
@@ -333,7 +341,7 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (title != null) 'title': title,
-      if (author != null) 'author': author,
+      if (authorNames != null) 'author_names': authorNames,
       if (body != null) 'body': body,
       if (year != null) 'year': year,
       if (altTitles != null) 'alt_titles': altTitles,
@@ -343,7 +351,7 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
   PoemsCompanion copyWith({
     Value<int>? id,
     Value<String>? title,
-    Value<String>? author,
+    Value<String>? authorNames,
     Value<String>? body,
     Value<String?>? year,
     Value<String?>? altTitles,
@@ -351,7 +359,7 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
     return PoemsCompanion(
       id: id ?? this.id,
       title: title ?? this.title,
-      author: author ?? this.author,
+      authorNames: authorNames ?? this.authorNames,
       body: body ?? this.body,
       year: year ?? this.year,
       altTitles: altTitles ?? this.altTitles,
@@ -367,8 +375,8 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
     if (title.present) {
       map['title'] = Variable<String>(title.value);
     }
-    if (author.present) {
-      map['author'] = Variable<String>(author.value);
+    if (authorNames.present) {
+      map['author_names'] = Variable<String>(authorNames.value);
     }
     if (body.present) {
       map['body'] = Variable<String>(body.value);
@@ -387,10 +395,474 @@ class PoemsCompanion extends UpdateCompanion<Poem> {
     return (StringBuffer('PoemsCompanion(')
           ..write('id: $id, ')
           ..write('title: $title, ')
-          ..write('author: $author, ')
+          ..write('authorNames: $authorNames, ')
           ..write('body: $body, ')
           ..write('year: $year, ')
           ..write('altTitles: $altTitles')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $AuthorsTable extends Authors with TableInfo<$AuthorsTable, Author> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $AuthorsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _poemCountMeta = const VerificationMeta(
+    'poemCount',
+  );
+  @override
+  late final GeneratedColumn<int> poemCount = GeneratedColumn<int>(
+    'poem_count',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [id, name, poemCount];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'authors';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<Author> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('poem_count')) {
+      context.handle(
+        _poemCountMeta,
+        poemCount.isAcceptableOrUnknown(data['poem_count']!, _poemCountMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_poemCountMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Author map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Author(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      poemCount: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}poem_count'],
+      )!,
+    );
+  }
+
+  @override
+  $AuthorsTable createAlias(String alias) {
+    return $AuthorsTable(attachedDatabase, alias);
+  }
+}
+
+class Author extends DataClass implements Insertable<Author> {
+  final int id;
+  final String name;
+  final int poemCount;
+  const Author({required this.id, required this.name, required this.poemCount});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    map['poem_count'] = Variable<int>(poemCount);
+    return map;
+  }
+
+  AuthorsCompanion toCompanion(bool nullToAbsent) {
+    return AuthorsCompanion(
+      id: Value(id),
+      name: Value(name),
+      poemCount: Value(poemCount),
+    );
+  }
+
+  factory Author.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Author(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      poemCount: serializer.fromJson<int>(json['poemCount']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'poemCount': serializer.toJson<int>(poemCount),
+    };
+  }
+
+  Author copyWith({int? id, String? name, int? poemCount}) => Author(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    poemCount: poemCount ?? this.poemCount,
+  );
+  Author copyWithCompanion(AuthorsCompanion data) {
+    return Author(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      poemCount: data.poemCount.present ? data.poemCount.value : this.poemCount,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Author(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('poemCount: $poemCount')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, poemCount);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Author &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.poemCount == this.poemCount);
+}
+
+class AuthorsCompanion extends UpdateCompanion<Author> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<int> poemCount;
+  const AuthorsCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.poemCount = const Value.absent(),
+  });
+  AuthorsCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    required int poemCount,
+  }) : name = Value(name),
+       poemCount = Value(poemCount);
+  static Insertable<Author> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<int>? poemCount,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (poemCount != null) 'poem_count': poemCount,
+    });
+  }
+
+  AuthorsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<int>? poemCount,
+  }) {
+    return AuthorsCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      poemCount: poemCount ?? this.poemCount,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (poemCount.present) {
+      map['poem_count'] = Variable<int>(poemCount.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('AuthorsCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('poemCount: $poemCount')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $PoemAuthorsTable extends PoemAuthors
+    with TableInfo<$PoemAuthorsTable, PoemAuthor> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PoemAuthorsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _poemIdMeta = const VerificationMeta('poemId');
+  @override
+  late final GeneratedColumn<int> poemId = GeneratedColumn<int>(
+    'poem_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES poems (id)',
+    ),
+  );
+  static const VerificationMeta _authorIdMeta = const VerificationMeta(
+    'authorId',
+  );
+  @override
+  late final GeneratedColumn<int> authorId = GeneratedColumn<int>(
+    'author_id',
+    aliasedName,
+    false,
+    type: DriftSqlType.int,
+    requiredDuringInsert: true,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'REFERENCES authors (id)',
+    ),
+  );
+  @override
+  List<GeneratedColumn> get $columns => [poemId, authorId];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'poem_authors';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<PoemAuthor> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('poem_id')) {
+      context.handle(
+        _poemIdMeta,
+        poemId.isAcceptableOrUnknown(data['poem_id']!, _poemIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_poemIdMeta);
+    }
+    if (data.containsKey('author_id')) {
+      context.handle(
+        _authorIdMeta,
+        authorId.isAcceptableOrUnknown(data['author_id']!, _authorIdMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_authorIdMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {poemId, authorId};
+  @override
+  PoemAuthor map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PoemAuthor(
+      poemId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}poem_id'],
+      )!,
+      authorId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}author_id'],
+      )!,
+    );
+  }
+
+  @override
+  $PoemAuthorsTable createAlias(String alias) {
+    return $PoemAuthorsTable(attachedDatabase, alias);
+  }
+}
+
+class PoemAuthor extends DataClass implements Insertable<PoemAuthor> {
+  final int poemId;
+  final int authorId;
+  const PoemAuthor({required this.poemId, required this.authorId});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['poem_id'] = Variable<int>(poemId);
+    map['author_id'] = Variable<int>(authorId);
+    return map;
+  }
+
+  PoemAuthorsCompanion toCompanion(bool nullToAbsent) {
+    return PoemAuthorsCompanion(
+      poemId: Value(poemId),
+      authorId: Value(authorId),
+    );
+  }
+
+  factory PoemAuthor.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PoemAuthor(
+      poemId: serializer.fromJson<int>(json['poemId']),
+      authorId: serializer.fromJson<int>(json['authorId']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'poemId': serializer.toJson<int>(poemId),
+      'authorId': serializer.toJson<int>(authorId),
+    };
+  }
+
+  PoemAuthor copyWith({int? poemId, int? authorId}) => PoemAuthor(
+    poemId: poemId ?? this.poemId,
+    authorId: authorId ?? this.authorId,
+  );
+  PoemAuthor copyWithCompanion(PoemAuthorsCompanion data) {
+    return PoemAuthor(
+      poemId: data.poemId.present ? data.poemId.value : this.poemId,
+      authorId: data.authorId.present ? data.authorId.value : this.authorId,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PoemAuthor(')
+          ..write('poemId: $poemId, ')
+          ..write('authorId: $authorId')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(poemId, authorId);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PoemAuthor &&
+          other.poemId == this.poemId &&
+          other.authorId == this.authorId);
+}
+
+class PoemAuthorsCompanion extends UpdateCompanion<PoemAuthor> {
+  final Value<int> poemId;
+  final Value<int> authorId;
+  final Value<int> rowid;
+  const PoemAuthorsCompanion({
+    this.poemId = const Value.absent(),
+    this.authorId = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PoemAuthorsCompanion.insert({
+    required int poemId,
+    required int authorId,
+    this.rowid = const Value.absent(),
+  }) : poemId = Value(poemId),
+       authorId = Value(authorId);
+  static Insertable<PoemAuthor> custom({
+    Expression<int>? poemId,
+    Expression<int>? authorId,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (poemId != null) 'poem_id': poemId,
+      if (authorId != null) 'author_id': authorId,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PoemAuthorsCompanion copyWith({
+    Value<int>? poemId,
+    Value<int>? authorId,
+    Value<int>? rowid,
+  }) {
+    return PoemAuthorsCompanion(
+      poemId: poemId ?? this.poemId,
+      authorId: authorId ?? this.authorId,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (poemId.present) {
+      map['poem_id'] = Variable<int>(poemId.value);
+    }
+    if (authorId.present) {
+      map['author_id'] = Variable<int>(authorId.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PoemAuthorsCompanion(')
+          ..write('poemId: $poemId, ')
+          ..write('authorId: $authorId, ')
+          ..write('rowid: $rowid')
           ..write(')'))
         .toString();
   }
@@ -608,19 +1080,26 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   $AppDatabaseManager get managers => $AppDatabaseManager(this);
   late final $PoemsTable poems = $PoemsTable(this);
+  late final $AuthorsTable authors = $AuthorsTable(this);
+  late final $PoemAuthorsTable poemAuthors = $PoemAuthorsTable(this);
   late final $MetadataTable metadata = $MetadataTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [poems, metadata];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [
+    poems,
+    authors,
+    poemAuthors,
+    metadata,
+  ];
 }
 
 typedef $$PoemsTableCreateCompanionBuilder =
     PoemsCompanion Function({
       Value<int> id,
       required String title,
-      required String author,
+      required String authorNames,
       required String body,
       Value<String?> year,
       Value<String?> altTitles,
@@ -629,11 +1108,34 @@ typedef $$PoemsTableUpdateCompanionBuilder =
     PoemsCompanion Function({
       Value<int> id,
       Value<String> title,
-      Value<String> author,
+      Value<String> authorNames,
       Value<String> body,
       Value<String?> year,
       Value<String?> altTitles,
     });
+
+final class $$PoemsTableReferences
+    extends BaseReferences<_$AppDatabase, $PoemsTable, Poem> {
+  $$PoemsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$PoemAuthorsTable, List<PoemAuthor>>
+  _poemAuthorsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.poemAuthors,
+    aliasName: $_aliasNameGenerator(db.poems.id, db.poemAuthors.poemId),
+  );
+
+  $$PoemAuthorsTableProcessedTableManager get poemAuthorsRefs {
+    final manager = $$PoemAuthorsTableTableManager(
+      $_db,
+      $_db.poemAuthors,
+    ).filter((f) => f.poemId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_poemAuthorsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
 
 class $$PoemsTableFilterComposer extends Composer<_$AppDatabase, $PoemsTable> {
   $$PoemsTableFilterComposer({
@@ -653,8 +1155,8 @@ class $$PoemsTableFilterComposer extends Composer<_$AppDatabase, $PoemsTable> {
     builder: (column) => ColumnFilters(column),
   );
 
-  ColumnFilters<String> get author => $composableBuilder(
-    column: $table.author,
+  ColumnFilters<String> get authorNames => $composableBuilder(
+    column: $table.authorNames,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -672,6 +1174,31 @@ class $$PoemsTableFilterComposer extends Composer<_$AppDatabase, $PoemsTable> {
     column: $table.altTitles,
     builder: (column) => ColumnFilters(column),
   );
+
+  Expression<bool> poemAuthorsRefs(
+    Expression<bool> Function($$PoemAuthorsTableFilterComposer f) f,
+  ) {
+    final $$PoemAuthorsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.poemAuthors,
+      getReferencedColumn: (t) => t.poemId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemAuthorsTableFilterComposer(
+            $db: $db,
+            $table: $db.poemAuthors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$PoemsTableOrderingComposer
@@ -693,8 +1220,8 @@ class $$PoemsTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
-  ColumnOrderings<String> get author => $composableBuilder(
-    column: $table.author,
+  ColumnOrderings<String> get authorNames => $composableBuilder(
+    column: $table.authorNames,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -729,8 +1256,10 @@ class $$PoemsTableAnnotationComposer
   GeneratedColumn<String> get title =>
       $composableBuilder(column: $table.title, builder: (column) => column);
 
-  GeneratedColumn<String> get author =>
-      $composableBuilder(column: $table.author, builder: (column) => column);
+  GeneratedColumn<String> get authorNames => $composableBuilder(
+    column: $table.authorNames,
+    builder: (column) => column,
+  );
 
   GeneratedColumn<String> get body =>
       $composableBuilder(column: $table.body, builder: (column) => column);
@@ -740,6 +1269,31 @@ class $$PoemsTableAnnotationComposer
 
   GeneratedColumn<String> get altTitles =>
       $composableBuilder(column: $table.altTitles, builder: (column) => column);
+
+  Expression<T> poemAuthorsRefs<T extends Object>(
+    Expression<T> Function($$PoemAuthorsTableAnnotationComposer a) f,
+  ) {
+    final $$PoemAuthorsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.poemAuthors,
+      getReferencedColumn: (t) => t.poemId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemAuthorsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.poemAuthors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
 }
 
 class $$PoemsTableTableManager
@@ -753,9 +1307,9 @@ class $$PoemsTableTableManager
           $$PoemsTableAnnotationComposer,
           $$PoemsTableCreateCompanionBuilder,
           $$PoemsTableUpdateCompanionBuilder,
-          (Poem, BaseReferences<_$AppDatabase, $PoemsTable, Poem>),
+          (Poem, $$PoemsTableReferences),
           Poem,
-          PrefetchHooks Function()
+          PrefetchHooks Function({bool poemAuthorsRefs})
         > {
   $$PoemsTableTableManager(_$AppDatabase db, $PoemsTable table)
     : super(
@@ -772,14 +1326,14 @@ class $$PoemsTableTableManager
               ({
                 Value<int> id = const Value.absent(),
                 Value<String> title = const Value.absent(),
-                Value<String> author = const Value.absent(),
+                Value<String> authorNames = const Value.absent(),
                 Value<String> body = const Value.absent(),
                 Value<String?> year = const Value.absent(),
                 Value<String?> altTitles = const Value.absent(),
               }) => PoemsCompanion(
                 id: id,
                 title: title,
-                author: author,
+                authorNames: authorNames,
                 body: body,
                 year: year,
                 altTitles: altTitles,
@@ -788,22 +1342,46 @@ class $$PoemsTableTableManager
               ({
                 Value<int> id = const Value.absent(),
                 required String title,
-                required String author,
+                required String authorNames,
                 required String body,
                 Value<String?> year = const Value.absent(),
                 Value<String?> altTitles = const Value.absent(),
               }) => PoemsCompanion.insert(
                 id: id,
                 title: title,
-                author: author,
+                authorNames: authorNames,
                 body: body,
                 year: year,
                 altTitles: altTitles,
               ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .map(
+                (e) =>
+                    (e.readTable(table), $$PoemsTableReferences(db, table, e)),
+              )
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({poemAuthorsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (poemAuthorsRefs) db.poemAuthors],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (poemAuthorsRefs)
+                    await $_getPrefetchedData<Poem, $PoemsTable, PoemAuthor>(
+                      currentTable: table,
+                      referencedTable: $$PoemsTableReferences
+                          ._poemAuthorsRefsTable(db),
+                      managerFromTypedResult: (p0) =>
+                          $$PoemsTableReferences(db, table, p0).poemAuthorsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.poemId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
         ),
       );
 }
@@ -818,9 +1396,610 @@ typedef $$PoemsTableProcessedTableManager =
       $$PoemsTableAnnotationComposer,
       $$PoemsTableCreateCompanionBuilder,
       $$PoemsTableUpdateCompanionBuilder,
-      (Poem, BaseReferences<_$AppDatabase, $PoemsTable, Poem>),
+      (Poem, $$PoemsTableReferences),
       Poem,
-      PrefetchHooks Function()
+      PrefetchHooks Function({bool poemAuthorsRefs})
+    >;
+typedef $$AuthorsTableCreateCompanionBuilder =
+    AuthorsCompanion Function({
+      Value<int> id,
+      required String name,
+      required int poemCount,
+    });
+typedef $$AuthorsTableUpdateCompanionBuilder =
+    AuthorsCompanion Function({
+      Value<int> id,
+      Value<String> name,
+      Value<int> poemCount,
+    });
+
+final class $$AuthorsTableReferences
+    extends BaseReferences<_$AppDatabase, $AuthorsTable, Author> {
+  $$AuthorsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$PoemAuthorsTable, List<PoemAuthor>>
+  _poemAuthorsRefsTable(_$AppDatabase db) => MultiTypedResultKey.fromTable(
+    db.poemAuthors,
+    aliasName: $_aliasNameGenerator(db.authors.id, db.poemAuthors.authorId),
+  );
+
+  $$PoemAuthorsTableProcessedTableManager get poemAuthorsRefs {
+    final manager = $$PoemAuthorsTableTableManager(
+      $_db,
+      $_db.poemAuthors,
+    ).filter((f) => f.authorId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_poemAuthorsRefsTable($_db));
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: cache),
+    );
+  }
+}
+
+class $$AuthorsTableFilterComposer
+    extends Composer<_$AppDatabase, $AuthorsTable> {
+  $$AuthorsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<int> get poemCount => $composableBuilder(
+    column: $table.poemCount,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  Expression<bool> poemAuthorsRefs(
+    Expression<bool> Function($$PoemAuthorsTableFilterComposer f) f,
+  ) {
+    final $$PoemAuthorsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.poemAuthors,
+      getReferencedColumn: (t) => t.authorId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemAuthorsTableFilterComposer(
+            $db: $db,
+            $table: $db.poemAuthors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$AuthorsTableOrderingComposer
+    extends Composer<_$AppDatabase, $AuthorsTable> {
+  $$AuthorsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<int> get poemCount => $composableBuilder(
+    column: $table.poemCount,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$AuthorsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $AuthorsTable> {
+  $$AuthorsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<int> get poemCount =>
+      $composableBuilder(column: $table.poemCount, builder: (column) => column);
+
+  Expression<T> poemAuthorsRefs<T extends Object>(
+    Expression<T> Function($$PoemAuthorsTableAnnotationComposer a) f,
+  ) {
+    final $$PoemAuthorsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.id,
+      referencedTable: $db.poemAuthors,
+      getReferencedColumn: (t) => t.authorId,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemAuthorsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.poemAuthors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return f(composer);
+  }
+}
+
+class $$AuthorsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $AuthorsTable,
+          Author,
+          $$AuthorsTableFilterComposer,
+          $$AuthorsTableOrderingComposer,
+          $$AuthorsTableAnnotationComposer,
+          $$AuthorsTableCreateCompanionBuilder,
+          $$AuthorsTableUpdateCompanionBuilder,
+          (Author, $$AuthorsTableReferences),
+          Author,
+          PrefetchHooks Function({bool poemAuthorsRefs})
+        > {
+  $$AuthorsTableTableManager(_$AppDatabase db, $AuthorsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$AuthorsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$AuthorsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$AuthorsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<int> poemCount = const Value.absent(),
+              }) => AuthorsCompanion(id: id, name: name, poemCount: poemCount),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String name,
+                required int poemCount,
+              }) => AuthorsCompanion.insert(
+                id: id,
+                name: name,
+                poemCount: poemCount,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$AuthorsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({poemAuthorsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [if (poemAuthorsRefs) db.poemAuthors],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (poemAuthorsRefs)
+                    await $_getPrefetchedData<
+                      Author,
+                      $AuthorsTable,
+                      PoemAuthor
+                    >(
+                      currentTable: table,
+                      referencedTable: $$AuthorsTableReferences
+                          ._poemAuthorsRefsTable(db),
+                      managerFromTypedResult: (p0) => $$AuthorsTableReferences(
+                        db,
+                        table,
+                        p0,
+                      ).poemAuthorsRefs,
+                      referencedItemsForCurrentItem: (item, referencedItems) =>
+                          referencedItems.where((e) => e.authorId == item.id),
+                      typedResults: items,
+                    ),
+                ];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$AuthorsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $AuthorsTable,
+      Author,
+      $$AuthorsTableFilterComposer,
+      $$AuthorsTableOrderingComposer,
+      $$AuthorsTableAnnotationComposer,
+      $$AuthorsTableCreateCompanionBuilder,
+      $$AuthorsTableUpdateCompanionBuilder,
+      (Author, $$AuthorsTableReferences),
+      Author,
+      PrefetchHooks Function({bool poemAuthorsRefs})
+    >;
+typedef $$PoemAuthorsTableCreateCompanionBuilder =
+    PoemAuthorsCompanion Function({
+      required int poemId,
+      required int authorId,
+      Value<int> rowid,
+    });
+typedef $$PoemAuthorsTableUpdateCompanionBuilder =
+    PoemAuthorsCompanion Function({
+      Value<int> poemId,
+      Value<int> authorId,
+      Value<int> rowid,
+    });
+
+final class $$PoemAuthorsTableReferences
+    extends BaseReferences<_$AppDatabase, $PoemAuthorsTable, PoemAuthor> {
+  $$PoemAuthorsTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $PoemsTable _poemIdTable(_$AppDatabase db) => db.poems.createAlias(
+    $_aliasNameGenerator(db.poemAuthors.poemId, db.poems.id),
+  );
+
+  $$PoemsTableProcessedTableManager get poemId {
+    final $_column = $_itemColumn<int>('poem_id')!;
+
+    final manager = $$PoemsTableTableManager(
+      $_db,
+      $_db.poems,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_poemIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+
+  static $AuthorsTable _authorIdTable(_$AppDatabase db) =>
+      db.authors.createAlias(
+        $_aliasNameGenerator(db.poemAuthors.authorId, db.authors.id),
+      );
+
+  $$AuthorsTableProcessedTableManager get authorId {
+    final $_column = $_itemColumn<int>('author_id')!;
+
+    final manager = $$AuthorsTableTableManager(
+      $_db,
+      $_db.authors,
+    ).filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_authorIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+      manager.$state.copyWith(prefetchedData: [item]),
+    );
+  }
+}
+
+class $$PoemAuthorsTableFilterComposer
+    extends Composer<_$AppDatabase, $PoemAuthorsTable> {
+  $$PoemAuthorsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$PoemsTableFilterComposer get poemId {
+    final $$PoemsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.poemId,
+      referencedTable: $db.poems,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemsTableFilterComposer(
+            $db: $db,
+            $table: $db.poems,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$AuthorsTableFilterComposer get authorId {
+    final $$AuthorsTableFilterComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.authorId,
+      referencedTable: $db.authors,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AuthorsTableFilterComposer(
+            $db: $db,
+            $table: $db.authors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PoemAuthorsTableOrderingComposer
+    extends Composer<_$AppDatabase, $PoemAuthorsTable> {
+  $$PoemAuthorsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$PoemsTableOrderingComposer get poemId {
+    final $$PoemsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.poemId,
+      referencedTable: $db.poems,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemsTableOrderingComposer(
+            $db: $db,
+            $table: $db.poems,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$AuthorsTableOrderingComposer get authorId {
+    final $$AuthorsTableOrderingComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.authorId,
+      referencedTable: $db.authors,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AuthorsTableOrderingComposer(
+            $db: $db,
+            $table: $db.authors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PoemAuthorsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $PoemAuthorsTable> {
+  $$PoemAuthorsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  $$PoemsTableAnnotationComposer get poemId {
+    final $$PoemsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.poemId,
+      referencedTable: $db.poems,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$PoemsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.poems,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+
+  $$AuthorsTableAnnotationComposer get authorId {
+    final $$AuthorsTableAnnotationComposer composer = $composerBuilder(
+      composer: this,
+      getCurrentColumn: (t) => t.authorId,
+      referencedTable: $db.authors,
+      getReferencedColumn: (t) => t.id,
+      builder:
+          (
+            joinBuilder, {
+            $addJoinBuilderToRootComposer,
+            $removeJoinBuilderFromRootComposer,
+          }) => $$AuthorsTableAnnotationComposer(
+            $db: $db,
+            $table: $db.authors,
+            $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+            joinBuilder: joinBuilder,
+            $removeJoinBuilderFromRootComposer:
+                $removeJoinBuilderFromRootComposer,
+          ),
+    );
+    return composer;
+  }
+}
+
+class $$PoemAuthorsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $PoemAuthorsTable,
+          PoemAuthor,
+          $$PoemAuthorsTableFilterComposer,
+          $$PoemAuthorsTableOrderingComposer,
+          $$PoemAuthorsTableAnnotationComposer,
+          $$PoemAuthorsTableCreateCompanionBuilder,
+          $$PoemAuthorsTableUpdateCompanionBuilder,
+          (PoemAuthor, $$PoemAuthorsTableReferences),
+          PoemAuthor,
+          PrefetchHooks Function({bool poemId, bool authorId})
+        > {
+  $$PoemAuthorsTableTableManager(_$AppDatabase db, $PoemAuthorsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PoemAuthorsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PoemAuthorsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PoemAuthorsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> poemId = const Value.absent(),
+                Value<int> authorId = const Value.absent(),
+                Value<int> rowid = const Value.absent(),
+              }) => PoemAuthorsCompanion(
+                poemId: poemId,
+                authorId: authorId,
+                rowid: rowid,
+              ),
+          createCompanionCallback:
+              ({
+                required int poemId,
+                required int authorId,
+                Value<int> rowid = const Value.absent(),
+              }) => PoemAuthorsCompanion.insert(
+                poemId: poemId,
+                authorId: authorId,
+                rowid: rowid,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map(
+                (e) => (
+                  e.readTable(table),
+                  $$PoemAuthorsTableReferences(db, table, e),
+                ),
+              )
+              .toList(),
+          prefetchHooksCallback: ({poemId = false, authorId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins:
+                  <
+                    T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic
+                    >
+                  >(state) {
+                    if (poemId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.poemId,
+                                referencedTable: $$PoemAuthorsTableReferences
+                                    ._poemIdTable(db),
+                                referencedColumn: $$PoemAuthorsTableReferences
+                                    ._poemIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+                    if (authorId) {
+                      state =
+                          state.withJoin(
+                                currentTable: table,
+                                currentColumn: table.authorId,
+                                referencedTable: $$PoemAuthorsTableReferences
+                                    ._authorIdTable(db),
+                                referencedColumn: $$PoemAuthorsTableReferences
+                                    ._authorIdTable(db)
+                                    .id,
+                              )
+                              as T;
+                    }
+
+                    return state;
+                  },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ),
+      );
+}
+
+typedef $$PoemAuthorsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $PoemAuthorsTable,
+      PoemAuthor,
+      $$PoemAuthorsTableFilterComposer,
+      $$PoemAuthorsTableOrderingComposer,
+      $$PoemAuthorsTableAnnotationComposer,
+      $$PoemAuthorsTableCreateCompanionBuilder,
+      $$PoemAuthorsTableUpdateCompanionBuilder,
+      (PoemAuthor, $$PoemAuthorsTableReferences),
+      PoemAuthor,
+      PrefetchHooks Function({bool poemId, bool authorId})
     >;
 typedef $$MetadataTableCreateCompanionBuilder =
     MetadataCompanion Function({
@@ -967,6 +2146,10 @@ class $AppDatabaseManager {
   $AppDatabaseManager(this._db);
   $$PoemsTableTableManager get poems =>
       $$PoemsTableTableManager(_db, _db.poems);
+  $$AuthorsTableTableManager get authors =>
+      $$AuthorsTableTableManager(_db, _db.authors);
+  $$PoemAuthorsTableTableManager get poemAuthors =>
+      $$PoemAuthorsTableTableManager(_db, _db.poemAuthors);
   $$MetadataTableTableManager get metadata =>
       $$MetadataTableTableManager(_db, _db.metadata);
 }

--- a/lib/db/seed_data.dart
+++ b/lib/db/seed_data.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:mneme/db/database.dart';
 
 Future<void> seedDatabase(AppDatabase db, {String? language}) async {
@@ -7,19 +5,19 @@ Future<void> seedDatabase(AppDatabase db, {String? language}) async {
     'en': [
       {
         'title': 'The Raven',
-        'author': json.encode(['Edgar Allan Poe']),
+        'author_names': 'Edgar Allan Poe',
         'body': 'Once upon a midnight dreary...',
         'year': '1845',
       },
       {
         'title': 'Ozymandias',
-        'author': json.encode(['Percy Bysshe Shelley']),
+        'author_names': 'Percy Bysshe Shelley',
         'body': 'I met a traveller from an antique land...',
         'year': '1818',
       },
       {
         'title': 'Daffodils',
-        'author': json.encode(['William Wordsworth']),
+        'author_names': 'William Wordsworth',
         'body': 'I wandered lonely as a cloud...',
         'year': '1807',
       },
@@ -27,13 +25,13 @@ Future<void> seedDatabase(AppDatabase db, {String? language}) async {
     'ru': [
       {
         'title': 'Я помню чудное мгновенье',
-        'author': json.encode(['Александр Пушкин']),
+        'author_names': 'Александр Пушкин',
         'body': 'Я помню чудное мгновенье:\nПередо мной явилась ты...',
         'year': '1825',
       },
       {
         'title': 'Silentium!',
-        'author': json.encode(['Фёдор Тютчев']),
+        'author_names': 'Фёдор Тютчев',
         'body': 'Молчи, скрывайся и таи\nИ чувства и мечты свои...',
         'year': '1830',
       },

--- a/lib/db/tables.dart
+++ b/lib/db/tables.dart
@@ -4,14 +4,28 @@ import 'package:drift/drift.dart';
 class Poems extends Table {
   IntColumn get id => integer().autoIncrement()();
   TextColumn get title => text()();
-  // Stores JSON array of author names, e.g., ["Author 1", "Author 2"]
-  TextColumn get author => text()();
+  // Stores denormalized author string for FTS, e.g. "Author 1, Author 2"
+  TextColumn get authorNames => text()();
   TextColumn get body => text()();
   // Stores single year as string (e.g., "1845") or range as JSON
   // array (e.g., "[1800, 1802]")
   TextColumn get year => text().nullable()();
   // Stores alternative titles from duplicate poems as JSON array
   TextColumn get altTitles => text().nullable()();
+}
+
+class Authors extends Table {
+  IntColumn get id => integer().autoIncrement()();
+  TextColumn get name => text()();
+  IntColumn get poemCount => integer()();
+}
+
+class PoemAuthors extends Table {
+  IntColumn get poemId => integer().references(Poems, #id)();
+  IntColumn get authorId => integer().references(Authors, #id)();
+
+  @override
+  Set<Column> get primaryKey => {poemId, authorId};
 }
 
 class Metadata extends Table {

--- a/test/tool/builder_test.dart
+++ b/test/tool/builder_test.dart
@@ -47,7 +47,7 @@ void main() {
 
       expect(result, isNotNull);
       expect(result!['title'], 'Test Poem');
-      expect(result['author'], '["Test Author"]');
+      expect(result['raw_authors'], ['Test Author']);
       expect(result['body'], 'Line 1\nLine 2');
       expect(result['year'], '2024');
     });
@@ -65,7 +65,7 @@ void main() {
 
       expect(result, isNotNull);
       expect(result!['title'], 'Anon Poem');
-      expect(result['author'], '["[Anonymous]"]');
+      expect(result['raw_authors'], ['[Anonymous]']);
     });
 
     test('handles list of authors', () {
@@ -83,7 +83,7 @@ void main() {
       final result = extractPoemData(json, 'en');
 
       expect(result, isNotNull);
-      expect(result!['author'], '["A1","A2"]');
+      expect(result!['raw_authors'], ['A1', 'A2']);
     });
 
     test('handles missing optional fields', () {


### PR DESCRIPTION
## Description

Implements support for multiple authors per poem.
- Adds \`Authors\` and \`PoemAuthors\` tables.
- Updates \`Poems\` table to use denormalized \`author_names\` for FTS.
- Updates ETL tool to handle manual ID assignment and populate all tables correctly.

Closes #15

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
